### PR TITLE
Update environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: morphometrics
 dependencies:
-  - python=3.9.0
+  - python=3.9
+  - conda-forge::pyqt
   - conda-forge::matplotlib=3.3.3
   - conda-forge::pandas
   - conda-forge::graph-tool


### PR DESCRIPTION
This PR:
* relaxes the pinned version of python (so we have `python=3.9` instead of `python=3.9.0`). This fixes the package conflicts I was seeing a lot of earlier.
* includes `pyqt` as a dependency from conda-forge (pyqt is needed for the pymeshlab dependency, I think it was - [more discussion here about Qt errors](https://github.com/GrotjahnLab/surface_morphometrics/issues/7#issuecomment-1113699818))
