### PR TITLE
Ensure compatibility with pymeshlab 2022.2.post3

### DIFF
--- a/xyz2ply.py
+++ b/xyz2ply.py
@@ -8,9 +8,15 @@ __email__ = "benjamin.barad@gmail.com"
 __license__ = "GPLv3"
 
 from sys import argv
+import importlib.metadata
 import glob
 import pymeshlab as pm
 import click
+
+# Make code compatible with API in pymeshlab 2022.2.post3
+PML_VER = importlib.metadata.version('pymeshlab')
+if PML_VER == '2022.2.post3':
+    pm.PercentageValue = pm.Percentage
 
 @click.command()
 @click.argument('xyzfile', type=str)

--- a/xyz2ply.py
+++ b/xyz2ply.py
@@ -13,7 +13,7 @@ import glob
 import pymeshlab as pm
 import click
 
-# Make code compatible with API in pymeshlab 2022.2.post3
+# Ensure compatibility with pymeshlab 2022.2.post3
 PML_VER = importlib.metadata.version('pymeshlab')
 if PML_VER == '2022.2.post3':
     pm.PercentageValue = pm.Percentage


### PR DESCRIPTION
Follow up on the discussion here https://github.com/GrotjahnLab/surface_morphometrics/issues/22#issuecomment-2192307029.

While running `surface_morphometrics` on a linux cluster I ran into (https://github.com/GrotjahnLab/surface_morphometrics/issues/22#issuecomment-2142666241) reported by @Kathir-66.

This PR applies the fix suggested [here](https://github.com/3DTopia/LGM/issues/2#issuecomment-1935105962), which I confirm solves the problem at least in my case and leaves things unchanged with newer versions of `pymeshlab`.

Thanks again for this package and also for kindly accepting contributions :)