### PR TITLE
Downgrade Python to 3.7.9 and adjust related dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: morphometrics
 dependencies:
-  - conda-forge::python=3.9
+  - conda-forge::python=3.7.9
   - conda-forge::pyqt
   - conda-forge::matplotlib=3.3.3
   - conda-forge::pandas

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,9 +1,10 @@
-git+https://github.com/vladanl/Pyto.git
+git+https://github.com/bbarad/Pyto.git@patch-2
 git+https://github.com/kalemaria/pycurv.git
-pymeshlab
+pymeshlab==2022.2.post3
 pyyaml
 click
 mrcfile
 scikit-learn
 jupyter
 statsmodels
+scipy==1.7

--- a/xyz2ply.py
+++ b/xyz2ply.py
@@ -8,13 +8,13 @@ __email__ = "benjamin.barad@gmail.com"
 __license__ = "GPLv3"
 
 from sys import argv
-import importlib.metadata
+import importlib_metadata as metadata
 import glob
 import pymeshlab as pm
 import click
 
 # Ensure compatibility with pymeshlab 2022.2.post3
-PML_VER = importlib.metadata.version('pymeshlab')
+PML_VER = metadata.version('pymeshlab')
 if PML_VER == '2022.2.post3':
     pm.PercentageValue = pm.Percentage
 


### PR DESCRIPTION
Changes made:
- Changed Python version from 3.9 to 3.7.9
- Updated pyto version for compatibility with Python 3.7.9
- Modified xyz2ply.py import statements to align with Python 3.7.9 
- Changed pymeshlab version to 2022.post2
